### PR TITLE
Remove all flake 8 issues

### DIFF
--- a/mypackage/__init__.py
+++ b/mypackage/__init__.py
@@ -1,1 +1,1 @@
-from .core import *
+from .core import *  # noqa: F401,F403

--- a/mypackage/core.py
+++ b/mypackage/core.py
@@ -1,1 +1,1 @@
-# Insert your code here. 
+# Insert your code here.

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,11 @@ REQUIRED = [
 # ------------------------------------------------
 # Except, perhaps the License and Trove Classifiers!
 
+try:
+    FileNotFoundError            # Python 3
+except NameError:
+    FileNotFoundError = IOError  # Python 2
+
 here = os.path.abspath(os.path.dirname(__file__))
 
 # Import the README and use it as the long-description.
@@ -45,7 +50,7 @@ class PublishCommand(Command):
 
     description = 'Build and publish the package.'
     user_options = []
-    
+
     @staticmethod
     def status(s):
         """Prints things in bold."""
@@ -65,7 +70,8 @@ class PublishCommand(Command):
             pass
 
         self.status('Building Source and Wheel (universal) distribution…')
-        os.system('{0} setup.py sdist bdist_wheel --universal '.format(sys.executable))
+        fmt = '{0} setup.py sdist bdist_wheel --universal '
+        os.system(fmt.format(sys.executable))
 
         self.status('Uploading the package to PyPi via Twine…')
         os.system('twine upload dist/*')
@@ -97,17 +103,17 @@ setup(
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         'License :: OSI Approved :: ISC License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
+        # 'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
+        # 'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],
-    # $ setup.py publish support. 
+    # $ setup.py publish support.
     cmdclass={
         'publish': PublishCommand,
     },


### PR DESCRIPTION
Some people will run flake8 on their repos so code in this repo should be flake8 neutral.

Also commented out trove classifiers for Python versions that are [EOL](https://docs.python.org/devguide/index.html#branchstatus) or will be EOL in the next 30 days.  

flake8 testing of https://github.com/kennethreitz/setup.py on Python 2.7.13

$ __flake8 . --count --exit-zero --max-complexity=10 --show-source --statistics__
```
./setup.py:48:1: W293 blank line contains whitespace
    
^

./setup.py:64:16: F821 undefined name 'FileNotFoundError'
        except FileNotFoundError:
               ^

./setup.py:68:80: E501 line too long (87 > 79 characters)
        os.system('{0} setup.py sdist bdist_wheel --universal '.format(sys.executable))
                                                                               ^

./setup.py:110:34: W291 trailing whitespace
    # $ setup.py publish support. 
                                 ^

./mypackage/__init__.py:1:1: F403 'from .core import *' used; unable to detect undefined names
from .core import *
^

./mypackage/__init__.py:1:1: F401 '.core.*' imported but unused
from .core import *
^

./mypackage/core.py:1:25: W291 trailing whitespace
# Insert your code here. 
                        ^

1     E501 line too long (87 > 79 characters)
1     F401 '.core.*' imported but unused
1     F403 'from .core import *' used; unable to detect undefined names
1     F821 undefined name 'FileNotFoundError'
2     W291 trailing whitespace
1     W293 blank line contains whitespace

7
```