### PR TITLE
use os.path.join everywhere

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ class PublishCommand(Command):
     def run(self):
         try:
             self.status('Removing previous builds…')
-            rmtree(os.sep.join(('.', 'dist')))
+            rmtree(os.path.join(here, 'dist'))
         except FileNotFoundError:
             pass
 


### PR DESCRIPTION
very minor
I don't think there is a reason to use `os.sep.join` instead of `os.path.join` as used in two other places.

