### PR TITLE
Giving supported platforms/versions a user interface

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ REQUIRED = [
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------
 # Except, perhaps the License and Trove Classifiers!
+# If you do change the License, remember to change the Trove Classifier for that!
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Defaults are important. Most people are just going to copy and paste this and be satisfied that it works after they (probably) change the things they're expected to change. That means it's important to give the user as much of a sense of control over the data they're probably going to change as we can. This PR defines an interface for changing the project's platform support and provides it to the user.

Also, it adds a comment reminding you to change the classifier to match your license if you change the license, because I've already forgotten to do that.