### PR TITLE
[Fixes #30] Add a VERSION tuple for comparison

### DIFF
--- a/mypackage/__version__.py
+++ b/mypackage/__version__.py
@@ -3,4 +3,6 @@
 # 88YbdP88   8P   88"""   dP__Yb  Yb      88"Yb   dP__Yb  Yb  "88 88""
 # 88 YY 88  dP    88     dP""""Yb  YboodP 88  Yb dP""""Yb  YboodP 888888
 
-__version__ = '5.2.0'
+VERSION = (5, 2, 0)
+
+__version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
Generate the __version__ string from the version tuple.

Having a tuple like this makes it easy for other packages to compare versions, e.g.:

    if VERSION > (3,):

    if VERSION < (1, 8):