### PR TITLE
Don't break if there's no __version__.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,11 @@ except FileNotFoundError:
 # Load the package's __version__.py module as a dictionary.
 about = {}
 if not VERSION:
-    with open(os.path.join(here, NAME, '__version__.py')) as f:
-        exec(f.read(), about)
+    try:
+        with open(os.path.join(here, NAME, '__version__.py')) as f:
+            exec(f.read(), about)
+    except FileNotFoundError:
+        pass
 else:
     about['__version__'] = VERSION
 


### PR DESCRIPTION
I just ran into this -- using your excellent setup.py example but not the entire repo, just setup.py. I also forgot to specify a version in the metadata.

`setup()` seems to work just fine without a version number, which is what I needed for local testing before submitting to PyPI and choosing a vision number. 

Thoughts?