### PR TITLE
Example hooks for binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # python package with setup.py
-=======================
 
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/cranmer/setup.py/master?filepath=example_notebook%2Fimport_mypackage.ipynb)
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ starting out — even Guido has been heard saying, "everyone cargo cults
 thems". It's true — so, I want this repo to be the best place to
 copy–paste from :)
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/cranmer/setup.py/master)
-
-
 [Check out the example!][an example setup.py]
+
+## Additions for binder
+
+It is convenient to provide an [example Jupyter notebook ](example_notebook/import_mypackage.ipynb) for a new package and add the hooks necessary to run the example with Binder. However, normally the package will not be included in the python path. To do that, one needs a setup.py for the package and to include `pip install -e .[develop]` in the [binder/postBuild](binder/postBuild) file. Once this is done, it is possible to use the package from within Binder.
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/cranmer/setup.py/master?filepath=example_notebook%2Fimport_mypackage.ipynb)
+
 
 ![image]
 

--- a/README.md
+++ b/README.md
@@ -1,59 +1,16 @@
-📦 setup.py (for humans)
+# python package with setup.py
 =======================
 
-This repo exists to provide [an example setup.py] file, that can be used
-to bootstrap your next Python project. It includes some advanced
-patterns and best practices for `setup.py`, as well as some
-commented–out nice–to–haves.
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/cranmer/setup.py/master?filepath=example_notebook%2Fimport_mypackage.ipynb)
 
-For example, this `setup.py` provides a `$ python setup.py upload`
-command, which creates a *universal wheel* (and *sdist*) and uploads
-your package to [PyPi] using [Twine], without the need for an annoying
-`setup.cfg` file. It also creates/uploads a new git tag, automatically.
+A Binder-compatible repo with a python package and a `setup.py` file.
 
-In short, `setup.py` files can be daunting to approach, when first
-starting out — even Guido has been heard saying, "everyone cargo cults
-thems". It's true — so, I want this repo to be the best place to
-copy–paste from :)
+Access this binder at the following URL:
 
-[Check out the example!][an example setup.py]
+https://mybinder.org/v2/gh/cranmer/setup.py/master?filepath=example_notebook%2Fimport_mypackage.ipynb
 
-## Additions for binder
+## Notes
 
-It is convenient to provide an [example Jupyter notebook ](example_notebook/import_mypackage.ipynb) for a new package and add the hooks necessary to run the example with Binder. However, normally the package will not be included in the python path. To do that, one needs a `setup.py` for the package (see [binder docs](https://mybinder.readthedocs.io/en/latest/using.html#setup-py)). Once this is done, it is possible to import the package in a notebook running within Binder. [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/cranmer/setup.py/master?filepath=example_notebook%2Fimport_mypackage.ipynb)
+It is convenient to provide an [example Jupyter notebook ](example_notebook/import_mypackage.ipynb) for a new package and add the hooks necessary to run the example with Binder. However, normally the package will not be included in the python path. To do that, one needs a `setup.py` for the package (see [binder docs](https://mybinder.readthedocs.io/en/latest/using.html#setup-py)). Once this is done, it is possible to import the package in a notebook running within Binder. 
 
-
-![image]
-
-To Do
------
-
--   Tests via `$ setup.py test` (if it's concise).
-
-Pull requests are encouraged!
-
-More Resources
---------------
-
--   [What is setup.py?] on Stack Overflow
--   [The Hitchhiker's Guide to Packaging]
--   [Cookiecutter template for a Python package]
-
-License
--------
-
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any means.
-
-✨🍰✨
-
-  [an example setup.py]: https://github.com/kennethreitz/setup.py/blob/master/setup.py
-  [PyPi]: https://docs.python.org/3/distutils/packageindex.html
-  [Twine]: https://pypi.python.org/pypi/twine
-  [image]: https://farm1.staticflickr.com/628/33173824932_58add34581_k_d.jpg
-  [What is setup.py?]: https://stackoverflow.com/questions/1471994/what-is-setup-py
-  [The Hitchhiker's Guide to Packaging]: https://the-hitchhikers-guide-to-packaging.readthedocs.io/en/latest/creation.html
-  [Cookiecutter template for a Python package]: https://github.com/audreyr/cookiecutter-pypackage
+This setup.py was adapted from https://github.com/kennethreitz/setup.py

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ copy–paste from :)
 
 ## Additions for binder
 
-It is convenient to provide an [example Jupyter notebook ](example_notebook/import_mypackage.ipynb) for a new package and add the hooks necessary to run the example with Binder. However, normally the package will not be included in the python path. To do that, one needs a setup.py for the package and to include `pip install -e .[develop]` in the [binder/postBuild](binder/postBuild) file. Once this is done, it is possible to use the package from within Binder.
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/cranmer/setup.py/master?filepath=example_notebook%2Fimport_mypackage.ipynb)
+It is convenient to provide an [example Jupyter notebook ](example_notebook/import_mypackage.ipynb) for a new package and add the hooks necessary to run the example with Binder. However, normally the package will not be included in the python path. To do that, one needs a `setup.py` for the package (see [binder docs](https://mybinder.readthedocs.io/en/latest/using.html#setup-py)). Once this is done, it is possible to import the package in a notebook running within Binder. [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/cranmer/setup.py/master?filepath=example_notebook%2Fimport_mypackage.ipynb)
 
 
 ![image]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ starting out — even Guido has been heard saying, "everyone cargo cults
 thems". It's true — so, I want this repo to be the best place to
 copy–paste from :)
 
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/cranmer/setup.py/master)
+
+
 [Check out the example!][an example setup.py]
 
 ![image]

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,0 @@
-pip install -e .[develop]

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,1 @@
+pip install -e .[develop]

--- a/example_notebook/import_mypackage.ipynb
+++ b/example_notebook/import_mypackage.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If mypackage isn't included in the python path, then one would need to add it"
+    "It is convenient to provide an [example Jupyter notebook ](example_notebook/import_mypackage.ipynb) for a new package and add the hooks necessary to run the example with Binder. However, normally the package will not be included in the python path. To do that, one needs a `setup.py` for the package (see [binder docs](https://mybinder.readthedocs.io/en/latest/using.html#setup-py)). Once this is done, it is possible to import the package in a notebook running within Binder."
    ]
   },
   {
@@ -13,6 +13,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# If mypackage isn't included in the python path, then one would need to add it\n",
+    "\n",
     "#import sys\n",
     "#sys.path.append('..')"
    ]
@@ -21,7 +23,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But by including `pip install -e .[develop]` in the `binder/postBuild` file, this isn't necessary."
+    "But if the repository has a `setup.py` binder (repo2docker) will run `pip install -e .`."
    ]
   },
   {

--- a/example_notebook/import_mypackage.ipynb
+++ b/example_notebook/import_mypackage.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "No module named 'mypackage'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-1-ebee4bc62610>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mmypackage\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m: No module named 'mypackage'"
+     ]
+    }
+   ],
+   "source": [
+    "import mypackage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'mypackage' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-66e9410a9bf6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mdir\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmypackage\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'mypackage' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "dir(mypackage)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/example_notebook/import_mypackage.ipynb
+++ b/example_notebook/import_mypackage.ipynb
@@ -1,53 +1,66 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If mypackage isn't included in the python path, then one would need to add it"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ImportError",
-     "evalue": "No module named 'mypackage'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-1-ebee4bc62610>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mmypackage\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mImportError\u001b[0m: No module named 'mypackage'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import mypackage"
+    "#import sys\n",
+    "#sys.path.append('..')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But by including `pip install -e .[develop]` in the `binder/postBuild` file, this isn't necessary."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mypackage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'mypackage' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-2-66e9410a9bf6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mdir\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmypackage\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m: name 'mypackage' is not defined"
-     ]
+     "data": {
+      "text/plain": [
+       "['__builtins__',\n",
+       " '__cached__',\n",
+       " '__doc__',\n",
+       " '__file__',\n",
+       " '__loader__',\n",
+       " '__name__',\n",
+       " '__package__',\n",
+       " '__path__',\n",
+       " '__spec__',\n",
+       " 'core']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "dir(mypackage)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -55,6 +68,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds an example notebook that imports the package. This doesn't add much for `setup.py` repository, but for those using Binder it's nice to have an example since you need a `setup.py` file to import the package automatically. Currently there is no example for binder (that I can find) that has a `setup.py`, so this repository seemed like the obvious place to start.