### PR TITLE
Use a valid python package name instead of just NAME to find the __version__.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,9 @@ except FileNotFoundError:
     long_description = DESCRIPTION
 
 # Load the package's __version__.py module as a dictionary.
-project_slug = NAME.lower().replace("-", "_").replace(" ", "_")
 about = {}
 if not VERSION:
+    project_slug = NAME.lower().replace("-", "_").replace(" ", "_")
     with open(os.path.join(here, project_slug, '__version__.py')) as f:
         exec(f.read(), about)
 else:

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,10 @@ except FileNotFoundError:
     long_description = DESCRIPTION
 
 # Load the package's __version__.py module as a dictionary.
+project_slug = NAME.lower().replace("-", "_").replace(" ", "_")
 about = {}
 if not VERSION:
-    with open(os.path.join(here, NAME, '__version__.py')) as f:
+    with open(os.path.join(here, project_slug, '__version__.py')) as f:
         exec(f.read(), about)
 else:
     about['__version__'] = VERSION


### PR DESCRIPTION
This will allow users to use package names like `pip tree` or `pip-tree` and still not break.