### PR TITLE
Refer users to find_namespace_packages() for python3 code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,8 @@ setup(
     python_requires=REQUIRES_PYTHON,
     url=URL,
     packages=find_packages(exclude=('tests',)),
+    # If you're using python3 implicit namespace packages (ie: no __init__.pys)
+    # you will want to use find_namespace_packages() instead.
     # If your package is a single module, use this instead of 'packages':
     # py_modules=['mypackage'],
 


### PR DESCRIPTION
I tried to use this excellent `setup.py` with my shiny new python3 code and it failed to find anything to build. After figuring out why (using python3 namespace packages) it seems like a good idea to help others via a comment.