### PR TITLE
Exclude all tests when discovering packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    packages=find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
     # If your package is a single module, use this instead of 'packages':
     # py_modules=['mypackage'],
 


### PR DESCRIPTION
As per the example here:
https://setuptools.readthedocs.io/en/latest/setuptools.html#using-find-packages