### PR TITLE
Fix formatting in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ class UploadCommand(Command):
         self.status('Pushing git tags…')
         os.system('git tag v{0}'.format(about['__version__']))
         os.system('git push --tags')
-        
+
         sys.exit()
 
 


### PR DESCRIPTION
Remove whitespace at end-of-line.

(Very minor but is jarring in many editors.)